### PR TITLE
Current Browser Tab PR Detection

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
   "permissions": [
     "storage",
     "alarms",
-    "activeTab", 
+    "activeTab",
+    "tabs",
     "sidePanel",
     "identity"
   ],

--- a/sidebar.css
+++ b/sidebar.css
@@ -568,6 +568,22 @@ body {
   white-space: nowrap;
 }
 
+/* Current Tab Indicator */
+.current-tab-indicator {
+  font-size: 9px;
+  padding: 2px 6px;
+  border-radius: 10px;
+  background: #0969da;
+  color: white;
+  font-weight: 500;
+  margin-left: 6px;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  animation: pulse 2s infinite;
+}
+
 
 /* Labels */
 .pr-labels {
@@ -808,6 +824,17 @@ body {
   to { 
     opacity: 1;
     transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes pulse {
+  0%, 100% { 
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% { 
+    opacity: 0.7;
+    transform: scale(0.95);
   }
 }
 


### PR DESCRIPTION
## Summary
• Detects GitHub PR currently open in browser tab
• Shows "👁️ Viewing" indicator with pulse animation  
• Real-time updates when switching tabs
• Added chrome.tabs API permission and event listeners

## Test plan
- [x] All unit tests passing (10/10)
- [x] All regression tests passing (10/10) 
- [x] Manual testing with tab switching
- [x] Visual indicator displays correctly

Phase 1 of current PR detection feature - addresses user request to "mark the PR I'm currently on in my browser."

🤖 Generated with [Claude Code](https://claude.ai/code)